### PR TITLE
fixed rendertostring hanging on the server with nested components

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -16,16 +16,15 @@ export default class Resolver {
     return Promise.all(promises);
   }
 
-  finish() {
+  finish(renderer, values=[]) {
     const total = this.promises.length;
-
-    return Promise.all(this.promises).then((values) => {
-      if (this.promises.length > total) {
-        return this.finish();
-      }
-
-      return values;
-    });
+    renderer();
+    if (this.promises.length > total) {
+      return Promise.all(this.promises).then((valueResults) => {
+        return this.finish(renderer, valueResults);
+      });
+    }
+    return Promise.resolve(values);
   }
 
   freeze() {
@@ -180,33 +179,31 @@ export default class Resolver {
     const resolver = new Resolver();
     const context = <Container resolver={resolver}>{element}</Container>;
 
-    React.renderToString(context);
-
-    return resolver.finish().then((data) => {
-      resolver.freeze();
-
-      var html = React.renderToString(context);
-      return {
-        data: resolver.states,
-        toString() { return html; },
-      };
-    });
+    return resolver.finish(()=>React.renderToString(context))
+      .then(() => {
+        resolver.freeze();
+        var html = React.renderToString(context);
+        return {
+          data: resolver.states,
+          toString() { return html; }
+        };
+      });
   }
 
   static renderToStaticMarkup(element) {
     const resolver = new Resolver();
     const context = <Container resolver={resolver}>{element}</Container>;
 
-    React.renderToStaticMarkup(context);
 
-    return resolver.finish().then((data) => {
+    return resolver.finish(()=>React.renderToStaticMarkup(context)).then(() => {
       resolver.freeze();
 
       var html = React.renderToStaticMarkup(context);
       return {
         data: resolver.states,
-        toString() { return html; },
+        toString() { return html; }
       };
     });
   }
+
 }


### PR DESCRIPTION
I found that when I have nested components with data that is resolved and where resolving that data creates the sub components renderToString (and I assume renderToStaticMarkup)  causes the server to hang.  This is because we need another call to the render method to bring in the newly created promises.

This should work for any number of such nested components.

Can do repo if you like?  
